### PR TITLE
Adding native C implementation for @stdlib/math/base/special/sin double `stdlib_base_sin ( const double x );`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sin/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/sin/binding.gyp
@@ -1,0 +1,52 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on for the sin function.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  "targets": [
+    {
+      "target_name": "sin-addon",
+      "sources": [ "addon.c" ],
+      "include_dirs": [ "include" ],
+      "cflags_cc": [ "-std=c99" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "conditions": [
+        ["OS=='linux'", {
+          "cflags": [ "-O3", "-Wall", "-Wextra" ],
+          "xcode_settings": {
+            "GCC_PREPROCESSOR_DEFINITIONS": [ "GNUC" ]
+          }
+        }],
+        ["OS=='mac'", {
+          "cflags": [ "-O3", "-Wall", "-Wextra" ],
+          "xcode_settings": {
+            "OTHER_CFLAGS": [ "-fno-objc-arc" ]
+          }
+        }],
+        ["OS=='win'", {
+          "cflags": [ "/O2", "/W4" ],
+          "msvs_settings": {
+            "VCCLCompilerTool": { "ExceptionHandling": 1 }
+          }
+        }]
+      ]
+    }
+  ]
+}
+

--- a/lib/node_modules/@stdlib/math/base/special/sin/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/sin/include.gypi
@@ -1,0 +1,35 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+  "variables": {
+    "src_dir": "./src",
+    "include_dirs": [
+      "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")"
+    ],
+    "addon_output_dir": "./src",
+    "src_files": [
+      "<(src_dir)/addon.c",
+      "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")"
+    ],
+    "libraries": [
+      "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")"
+    ],
+    "library_dirs": [
+      "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")"
+    ]
+  }
+}

--- a/lib/node_modules/@stdlib/math/base/special/sin/include/stdlib/math/base/special/kernel_sin.h
+++ b/lib/node_modules/@stdlib/math/base/special/sin/include/stdlib/math/base/special/kernel_sin.h
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_KERNEL_SIN_H
+#define STDLIB_MATH_BASE_SPECIAL_KERNEL_SIN_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the sine of a double-precision floating-point number on [-π/4, π/4].
+*/
+double stdlib_base_kernel_sin( const double x, const double y );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_KERNEL_SIN_H
+

--- a/lib/node_modules/@stdlib/math/base/special/sin/include/stdlib/math/base/special/sin.h
+++ b/lib/node_modules/@stdlib/math/base/special/sin/include/stdlib/math/base/special/sin.h
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef #ifndef STDLIB_MATH_BASE_SPECIAL_SIN_H
+#define #ifndef STDLIB_MATH_BASE_SPECIAL_SIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double stdlib_base_sin(const double x);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SIN_H */

--- a/lib/node_modules/@stdlib/math/base/special/sin/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sin/manifest.json
@@ -1,0 +1,76 @@
+{
+  "name": "sin",
+  "version": "1.0.0",
+  "description": "Node.js addon for computing the sine function.",
+  "main": "index.js",
+  "scripts": {
+    "build": "node-gyp configure build",
+    "clean": "node-gyp clean"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "node-addon-api": "^4.0.6"
+  },
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": []
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/sin/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/sin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/special/sin",
-  "version": "0.0.0",
-  "description": "Compute the sine of a number.",
+  "version": "1.0.0",
+  "description": "Node.js addon for computing the sine function.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -14,15 +14,17 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",
-  "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
@@ -53,12 +55,13 @@
     "stdmath",
     "mathematics",
     "math",
-    "math.sin",
-    "sin",
-    "sine",
-    "trig",
+    "special functions",
+    "special",
+    "function",
     "trigonometry",
-    "radians",
-    "angle"
+    "sine",
+    "sin"
   ]
+}
+
 }

--- a/lib/node_modules/@stdlib/math/base/special/sin/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/sin/src/Makefile
@@ -1,0 +1,43 @@
+## @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# variables #
+
+CC := gcc
+CFLAGS := -std=c99 -pedantic-errors -Wall -Wextra -Werror
+LDFLAGS := -lm
+TARGET := sin
+
+# src files #
+
+SRC := $(wildcard *.c)
+OBJ := $(SRC:.c=.o)
+
+# rules and terminologies #
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+    $(CC) $(CFLAGS) $(OBJ) -o $(TARGET) $(LDFLAGS)
+
+%.o: %.c
+    $(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+    rm -f $(OBJ) $(TARGET)
+
+.PHONY: all clean
+

--- a/lib/node_modules/@stdlib/math/base/special/sin/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/sin/src/addon.c
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/sin.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include <assert.h>
+#include <node_api.h>
+
+// Exported function to compute the sine of a number
+napi_value Sin(napi_env env, napi_callback_info info) {
+
+    size_t argc = 1;
+    napi_value args[1];
+    double x;
+    napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+    napi_get_value_double(env, args[0], &x);
+
+    // Call the stdlib sin function
+    double result = stdlib_base_sin(x);
+
+    napi_value js_result;
+    napi_create_double(env, result, &js_result);
+
+    return js_result;
+}
+
+
+napi_value Init(napi_env env, napi_value exports) {
+    //The 'sin' function is hence available for export
+    napi_property_descriptor desc = { "sin", NULL, Sin, NULL, NULL, NULL, napi_default, NULL };
+    napi_define_properties(env, exports, 1, &desc);
+
+    return exports;
+}
+
+// Create a Node.js addon module
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
+
+
+

--- a/lib/node_modules/@stdlib/math/base/special/sin/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sin/src/main.c
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* ## Notice
+*
+* The following copyright, license, and long comment were part of the original implementation available as part of [FreeBSD]{@link https://svnweb.freebsd.org/base/release/9.3.0/lib/msun/src/k_sin.c}. The implementation follows the original, but has been modified according to project conventions.
+*
+* ```text
+* Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+*
+* Developed at SunPro, a Sun Microsystems, Inc. business.
+* Permission to use, copy, modify, and distribute this
+* software is freely granted, provided that this notice
+* is preserved.
+* ```
+*/
+
+#include "stdlib/math/base/special/kernel_sin.h"
+#include <stdio.h>
+#include <math.h>
+
+#define M_PI 3.141592653589793
+
+double stdlib_base_sin(const double x) {
+
+    double reduced_x = fmod(x, 2.0 * M_PI); // Here x is reduced to the range [-pi, pi]
+    if (reduced_x < -M_PI) {
+        reduced_x += 2.0 * M_PI;
+    }
+    else if (reduced_x > M_PI) {
+        reduced_x -= 2.0 * M_PI;
+    }
+
+    if (reduced_x < 0) {
+        return -stdlib_base_kernel_sin(-reduced_x, 0.0);
+    }
+    else {
+        return stdlib_base_kernel_sin(reduced_x, 0.0);
+    }
+}
+


### PR DESCRIPTION
Resolves # .

## Description

> What is the purpose of this pull request?

This pull request:
Adds native C implementation for @stdlib/math/base/special/sin
`double stdlib_base_sin ( const double x );`
## Related Issues
Issue Tracker: https://github.com/stdlib-js/stdlib/issues/2018#issue-2204333546


This pull request:
1) Adds C Implementation of @stdlib/node_moudles/math/base/special/sin

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [ ] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
